### PR TITLE
fix: Pin to specific Home Assistant base image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,12 +40,9 @@ jobs:
           scandir: "./nolongerevil"
 
   build:
-    name: Build (${{ matrix.arch }})
+    name: Build
     runs-on: ubuntu-latest
     needs: lint
-    strategy:
-      matrix:
-        arch: [amd64, aarch64]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -58,22 +55,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Get platform
-        id: platform
-        run: |
-          case "${{ matrix.arch }}" in
-            amd64) echo "platform=linux/amd64" >> "$GITHUB_OUTPUT" ;;
-            aarch64) echo "platform=linux/arm64" >> "$GITHUB_OUTPUT" ;;
-          esac
-
       - name: Build
         uses: docker/build-push-action@v5
         with:
           context: ./nolongerevil
           file: ./nolongerevil/Dockerfile
-          platforms: ${{ steps.platform.outputs.platform }}
+          platforms: |
+            linux/amd64
+            linux/arm64
           push: false
-          build-args: |
-            BUILD_FROM=ghcr.io/home-assistant/${{ matrix.arch }}-base:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,7 @@ Follow the [Home Assistant Add-on Development Tutorial](https://developers.home-
 ### Building Locally
 
 ```bash
-cd nolongerevil
-docker build \
-  --build-arg BUILD_FROM=ghcr.io/home-assistant/amd64-base:latest \
-  -t nolongerevil-addon .
+docker build -t nolongerevil-addon ./nolongerevil
 ```
 
 ### Testing

--- a/nolongerevil/Dockerfile
+++ b/nolongerevil/Dockerfile
@@ -1,8 +1,5 @@
-ARG BUILD_FROM=ghcr.io/home-assistant/base:latest
+ARG BUILD_FROM=ghcr.io/home-assistant/base-python:3.12-alpine3.24
 FROM $BUILD_FROM
-
-# Install dependencies
-RUN apk add --no-cache python3 py3-pip
 
 # Build Python server
 WORKDIR /server


### PR DESCRIPTION
The previous Dockerfile used the `latest` Home Assistant base image. This may lead to issues in the future as they release new images with new versions of Python and Alpine. I updated the Dockerfile to use their `python:3.12-alpine3.24` image (Python 3.12 matches the version currently targeted by `NoLongerEvil-SelfHosted`). This, of course, has Python preinstalled, so I removed the command to install Python and pip.

The [README for the Home Assistant base images](https://github.com/home-assistant/docker-base/blob/d2bed106f864a4f7b3599b5151661ae6dc617c61/README.md) recommends using the multi-arch images instead of the old architecture-prefixed images. So, I updated `build.yaml` to not pass those arch-prefixed images to the Dockerfile. Instead, it passes the two target platforms to `docker/build-push-action`, which automatically builds an image for each platform using the multi-arch base specified in the Dockerfile. Likewise, I updated the `docker build` command in `CONTRIBUTING.md` to not specify an arch-prefixed base.